### PR TITLE
clang-tidyの設定ファイルを作成＆Github Actionで実行するように

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,91 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.bzero,readability-convert-member-functions-to-static,readability-const-return-type,readability-identifier-naming,readability-make-member-function-const,readability-non-const-parameter,readability-qualified-auto,readability-redundant-control-flow,readability-redundant-member-init,readability-else-after-return,readability-implicit-bool-conversion,readability-simplify-boolean-expr,readability-static-accessed-through-instance,cppcoreguidelines-init-variables,cppcoreguidelines-virtual-class-destructor,cppcoreguidelines-prefer-member-initializer,llvm-include-order,misc-definitions-in-headers,misc-unused-parameters,modernize-redundant-void-arg,modernize-use-bool-literals,bugprone-copy-constructor-init,bugprone-virtual-near-miss,portability-restrict-system-includes,performance-for-range-copy,performance-inefficient-vector-operation,performance-type-promotion-in-math-fn-tidy'
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-init-variables.IncludeStyle
+    value:           llvm
+  - key:             cppcoreguidelines-init-variables.MathHeader
+    value:           math.h
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           '0'
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           '0'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           '0'
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           ';h;hh;hpp;hxx'
+  - key:             misc-definitions-in-headers.UseHeaderFileExtension
+    value:           'true'
+  - key:             misc-unused-parameters.StrictMode
+    value:           'false'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-bool-literals.IgnoreMacros
+    value:           'true'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             performance-for-range-copy.AllowedTypes
+    value:           ''
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           'false'
+  - key:             performance-inefficient-vector-operation.EnableProto
+    value:           'false'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             portability-restrict-system-includes.Includes
+    value:           '*'
+  - key:             readability-else-after-return.WarnOnConditionVariables
+    value:           'true'
+  - key:             readability-else-after-return.WarnOnUnfixable
+    value:           'true'
+  - key:             readability-identifier-naming.AggressiveDependentMemberLookup
+    value:           'false'
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           'false'
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           'false'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           'false'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           'false'
+  - key:             readability-qualified-auto.AddConstToQualified
+    value:           'true'
+  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value:           'false'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           'false'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           'false'
+  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value:           '3'
+...
+

--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -14,6 +14,9 @@ jobs:
       - name: cpplint
         shell: bash
         run: docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv make lint
+      - name: clang-tidy
+        shell: bash
+        run: docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv make tidy
       - name: Googleテスト
         shell: bash
         run: docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv make test

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ lint: ## Lint webserver source files
 
 .PHONY: tidy
 tidy: ## Tidy webserver source files
-	clang-tidy srcs/**/*.hpp srcs/**/*.cpp -fix -header-filter=.* \
-		-checks=-clang-analyzer-security.insecureAPI.bzero,readability-convert-member-functions-to-static,readability-const-return-type,readability-identifier-naming,readability-make-member-function-const,readability-non-const-parameter,readability-qualified-auto,readability-redundant-control-flow,readability-redundant-member-init,readability-else-after-return,readability-implicit-bool-conversion,readability-simplify-boolean-expr,readability-static-accessed-through-instance,cppcoreguidelines-init-variables,cppcoreguidelines-virtual-class-destructor,cppcoreguidelines-prefer-member-initializer,llvm-include-order,misc-definitions-in-headers,misc-unused-parameters,modernize-redundant-void-arg,modernize-use-bool-literals,bugprone-copy-constructor-init,bugprone-virtual-near-miss,portability-restrict-system-includes,performance-for-range-copy,performance-inefficient-vector-operation,performance-type-promotion-in-math-fn,
+	clang-tidy srcs/**/*.hpp srcs/**/*.cpp -fix
 
 # ------------------------ Rules For Developer ----------------------------
 


### PR DESCRIPTION
設定ファイルについては `-dump-config`オプションをつけてclang-tidyを実行することで書き出した。
実行時には.clang-tidyの設定を優先してみてくれていそう。