### PR TITLE
cpplintがコケているのを修正

### DIFF
--- a/srcs/Http/HTTPRequest.hpp
+++ b/srcs/Http/HTTPRequest.hpp
@@ -7,7 +7,7 @@
 #include "Socket.hpp"
 #include "utils.hpp"
 
-const std::string CRLF = "\r\n";
+const std::string CRLF = "\r\n";  // NOLINT
 
 class HTTPRequest {
  public:


### PR DESCRIPTION
charで定義すると使い勝手が悪いのと、const exprが使えないので色々めんどくさかったりする。