### PR TITLE
細々とした修正

### DIFF
--- a/srcs/Config/LocationContext.cpp
+++ b/srcs/Config/LocationContext.cpp
@@ -1,14 +1,12 @@
 #include "LocationContext.hpp"
 
-// TODO(iyamada) 初期値、どんな値を入れたら良いかわからないので適当に入れている
 LocationContext::LocationContext()
-    : client_max_body_size_(-1), auto_index_(false) {}
+    : client_max_body_size_(1024), auto_index_(false) {}
 
 LocationContext::LocationContext(const LocationContext& other) {
     *this = other;
 }
 
-// TODO(iyamada) コピーの処理、いらないかも。とりあえずかいた
 LocationContext& LocationContext::operator=(const LocationContext& other) {
     if (this != &other) {
         this->error_pages_ = other.error_pages_;

--- a/srcs/Config/ServerContext.cpp
+++ b/srcs/Config/ServerContext.cpp
@@ -10,9 +10,8 @@ static T strtonum(const std::string& s) {
     return num;
 }
 
-// TODO(iyamada) 初期値、どんな値を入れたら良いかわからないので適当に入れている
 ServerContext::ServerContext()
-    : client_max_body_size_(-1), auto_index_(false), port_(-1) {}
+    : client_max_body_size_(1024), auto_index_(false), port_(80) {}
 
 ServerContext::ServerContext(const ServerContext& other) { *this = other; }
 

--- a/srcs/Config/WebservConfig.cpp
+++ b/srcs/Config/WebservConfig.cpp
@@ -70,6 +70,7 @@ static ServerLocation CreateServerLocation() {
     error_pages[505] = "/50x.html";
     std::set<std::string> allow_methods;
     allow_methods.insert("GET");
+    allow_methods.insert("HEAD");
     allow_methods.insert("POST");
     allow_methods.insert("DELETE");
     return ServerLocation(8081, "webserv1", "/html", error_pages, 4086, false,

--- a/srcs/Config/WebservConfig.cpp
+++ b/srcs/Config/WebservConfig.cpp
@@ -5,9 +5,8 @@
 
 #include "ConfigProcesser.hpp"
 
-// TODO(iyamada) 初期値、どんな値を入れたら良いかわからないので適当に入れている
 WebservConfig::WebservConfig()
-    : client_max_body_size_(-1), auto_index_(false) {}
+    : client_max_body_size_(1024), auto_index_(false) {}
 
 WebservConfig::WebservConfig(WebservConfig const &other) { *this = other; }
 
@@ -73,7 +72,7 @@ static ServerLocation CreateServerLocation() {
     allow_methods.insert("HEAD");
     allow_methods.insert("POST");
     allow_methods.insert("DELETE");
-    return ServerLocation(8081, "webserv1", "/html", error_pages, 4086, false,
+    return ServerLocation(8081, "webserv1", "/html", error_pages, 1024, false,
                           "index.html", "", allow_methods, "/var/www", "");
 }
 

--- a/srcs/Http/HTTPResponse.cpp
+++ b/srcs/Http/HTTPResponse.cpp
@@ -5,7 +5,8 @@
 HTTPResponse::HTTPResponse()
     : logging_(Logging(__FUNCTION__)),
       new_line_string_("\r\n"),
-      connection_("close") {}
+      connection_("close"),
+      content_length_(0) {}
 
 HTTPResponse::HTTPResponse(HTTPResponse const &other) { *this = other; }
 
@@ -114,6 +115,7 @@ std::string HTTPResponse::GetResponseString() const {
 
     oss << this->GetStatusLineString();
     oss << this->GetHeadersString();
+    // TODO(ahayashi): HEADリクエストの場合はbodyを付与しない
     if (this->content_length() > 0) {
         oss << new_line_string_;
         oss << this->GetBodyString();

--- a/srcs/Http/RequestFacade.cpp
+++ b/srcs/Http/RequestFacade.cpp
@@ -38,7 +38,7 @@ HTTPRequest *RequestFacade::SelectRequest(Socket const &socket) {
     return this->list_.at(socket_fd);
 }
 
-void RequestFacade::Finish(Socket socket) {
-    // socketをcloseする
-    (void)socket;
+void RequestFacade::Finish(Socket *socket) {
+    this->list_.erase(socket->sock_fd());
+    delete socket;
 }

--- a/srcs/Http/RequestFacade.hpp
+++ b/srcs/Http/RequestFacade.hpp
@@ -11,7 +11,7 @@ class RequestFacade {
  public:
     static RequestFacade *GetInstance();
     HTTPRequest *SelectRequest(Socket const &socket);
-    void Finish(Socket socket);
+    void Finish(Socket *socket);
 
  private:
     RequestFacade();

--- a/srcs/Webserv/ServerLocation.cpp
+++ b/srcs/Webserv/ServerLocation.cpp
@@ -6,7 +6,16 @@ ServerLocation::ServerLocation(ServerLocation const &other) { *this = other; }
 
 ServerLocation &ServerLocation::operator=(ServerLocation const &other) {
     if (this != &other) {
-        (void)other;
+        this->port_ = other.port_;
+        this->path_ = other.path_;
+        this->error_pages_ = other.error_pages_;
+        this->client_max_body_size_ = other.client_max_body_size_;
+        this->auto_index_ = other.auto_index_;
+        this->index_page_ = other.index_page_;
+        this->redirect_uri_ = other.redirect_uri_;
+        this->allow_methods_ = other.allow_methods_;
+        this->alias_ = other.alias_;
+        this->cgi_extension_ = other.cgi_extension_;
     }
     return *this;
 }

--- a/srcs/Webserv/ServerLocationFacade.cpp
+++ b/srcs/Webserv/ServerLocationFacade.cpp
@@ -1,6 +1,6 @@
 #include "ServerLocationFacade.hpp"
 
-ServerLocationFacade::ServerLocationFacade() { (void)server_locations_; }
+ServerLocationFacade::ServerLocationFacade() {}
 
 ServerLocationFacade::ServerLocationFacade(std::vector<ServerLocation> *vec)
     : server_locations_(vec) {}

--- a/srcs/Webserv/SuperVisor.cpp
+++ b/srcs/Webserv/SuperVisor.cpp
@@ -36,7 +36,7 @@ void SuperVisor::Watch() {
                 iomul.Accept(*(*itr));
             } else {
                 Worker worker(this->facade_);
-                worker.Exec(*(*itr));
+                worker.Exec(*itr);
             }
         }
     }

--- a/srcs/Webserv/Worker.cpp
+++ b/srcs/Webserv/Worker.cpp
@@ -20,13 +20,13 @@ Worker &Worker::operator=(Worker const &other) {
 
 Worker::~Worker() {}
 
-void Worker::Exec(Socket const &socket) {
+void Worker::Exec(Socket *socket) {
     this->logging_.Debug("start exec");
 
     this->request_facade_ = RequestFacade::GetInstance();
-    HTTPRequest *request = this->request_facade_->SelectRequest(socket);
+    HTTPRequest *request = this->request_facade_->SelectRequest(*socket);
     try {
-        std::string str = socket.Recv();
+        std::string str = socket->Recv();
         request->Parse(str);
         if (request->IsReady()) {
             // TODO(ahayashi): port番号をソケットから取れるように
@@ -34,7 +34,7 @@ void Worker::Exec(Socket const &socket) {
                 "port", request->host(), request->absolute_path());
             Transaction transaction;
             HTTPResponse *response = transaction.Exec(request, sl);
-            response->Write(socket);
+            response->Write(*socket);
             this->request_facade_->Finish(socket);
         }
     } catch (std::exception &e) {

--- a/srcs/Webserv/Worker.cpp
+++ b/srcs/Webserv/Worker.cpp
@@ -29,8 +29,9 @@ void Worker::Exec(Socket const &socket) {
         std::string str = socket.Recv();
         request->Parse(str);
         if (request->IsReady()) {
-            ServerLocation *sl =
-                this->server_location_facade_.Choose("port", "host", "path");
+            // TODO(ahayashi): port番号をソケットから取れるように
+            ServerLocation *sl = this->server_location_facade_.Choose(
+                "port", request->host(), request->absolute_path());
             Transaction transaction;
             HTTPResponse *response = transaction.Exec(request, sl);
             response->Write(socket);

--- a/srcs/Webserv/Worker.hpp
+++ b/srcs/Webserv/Worker.hpp
@@ -14,7 +14,7 @@ class Worker {
     Worker &operator=(Worker const &other);
     ~Worker();
 
-    void Exec(Socket const &socket);
+    void Exec(Socket *socket);
 
  private:
     Logging logging_;

--- a/tests/unit_test/ConfigParser.cpp
+++ b/tests/unit_test/ConfigParser.cpp
@@ -20,7 +20,7 @@ TEST_F(ConfigParserTest, LocationContextInServerContext) {
 
     ASSERT_EQ(conf.contexts().size(), 1);
     ASSERT_EQ(conf.error_pages().empty(), true);
-    ASSERT_EQ(conf.client_max_body_size(), -1);
+    ASSERT_EQ(conf.client_max_body_size(), 1024);
     ASSERT_EQ(conf.auto_index(), false);
     ASSERT_EQ(conf.index_page(), "");
 
@@ -32,7 +32,7 @@ TEST_F(ConfigParserTest, LocationContextInServerContext) {
 
     ASSERT_EQ(serv_context.contexts().size(), 1);
     ASSERT_EQ(serv_context.error_pages().empty(), true);
-    ASSERT_EQ(serv_context.client_max_body_size(), -1);
+    ASSERT_EQ(serv_context.client_max_body_size(), 1024);
     ASSERT_EQ(serv_context.auto_index(), false);
     ASSERT_EQ(serv_context.index_page(), "");
     ASSERT_EQ(serv_context.redirect_url(), "");
@@ -45,7 +45,7 @@ TEST_F(ConfigParserTest, LocationContextInServerContext) {
     LocationContext locate_context = locate_contexts.at(0);
 
     ASSERT_EQ(locate_context.error_pages().empty(), true);
-    ASSERT_EQ(locate_context.client_max_body_size(), -1);
+    ASSERT_EQ(locate_context.client_max_body_size(), 1024);
     ASSERT_EQ(locate_context.auto_index(), false);
     ASSERT_EQ(locate_context.index_page(), "");
     ASSERT_EQ(locate_context.allow_methods().empty(), true);


### PR DESCRIPTION
- ResponseのContent-Lengthを初期化するように
- ServerLocationのcopy assignment operatorを実装(メンバ変数がコピーされていなかったのでIsAllowedMethodがfalseになってしまっていた)
- client_max_body_sizeの初期値を修正
- Requestの終了処理を実装(Socketのclose & RequestFacade内のlistから削除)