### PR TITLE
ディレクティブ追加対応

### DIFF
--- a/docs/class/config_parser_class.md
+++ b/docs/class/config_parser_class.md
@@ -88,6 +88,7 @@ classDiagram
 | LocationContextNode | "location"コンテキスト |
 | ListenDirectiveNode | "listen"ディレクティブ  |
 | AliasDirectiveNode  | "alias"ディレクティブ   |
+| AutoindexDirectiveNode  | "autoindex"ディレクティブ   |
 
 ## Configファイルの文法
 
@@ -98,8 +99,8 @@ classDiagram
 ```
 config             ::= block_directive
 block_directive    ::= ("server" | "location" value ) "{" ( single_directive | location_directive ) "}"
-location_directive ::= "location" value "{" ( single_directive ) "}"
-single_directive   ::= ( "listen" | "alias" ) value ";"
+location_directive ::= "location" value "{" ( single_directive )+ "}"
+single_directive   ::= ( "listen" | "alias" | "autoindex" ) value ";"
 value              ::= (英数字 | ".")+
 ```
 

--- a/docs/class/config_parser_class.md
+++ b/docs/class/config_parser_class.md
@@ -81,14 +81,14 @@ classDiagram
 
 ## NodeKindの種類
 
-| kind名               | 説明               |
-| ------------------- | ---------------- |
-| HttpContextNode     | "http"コンテキスト     |
-| ServerContextNode   | "server"コンテキスト   |
-| LocationContextNode | "location"コンテキスト |
-| ListenDirectiveNode | "listen"ディレクティブ  |
-| AliasDirectiveNode  | "alias"ディレクティブ   |
-| AutoindexDirectiveNode  | "autoindex"ディレクティブ   |
+| kind名                  | 説明                 |
+| ---------------------- | ------------------ |
+| HttpContextNode        | "http"コンテキスト       |
+| ServerContextNode      | "server"コンテキスト     |
+| LocationContextNode    | "location"コンテキスト   |
+| ListenDirectiveNode    | "listen"ディレクティブ    |
+| AliasDirectiveNode     | "alias"ディレクティブ     |
+| AutoindexDirectiveNode | "autoindex"ディレクティブ |
 
 ## Configファイルの文法
 

--- a/docs/class/config_parser_class.md
+++ b/docs/class/config_parser_class.md
@@ -72,7 +72,7 @@ classDiagram
 
 | kind名                | 説明                   |
 | -------------------- | -------------------- |
-| BlockDirectiveToken  | "server"             |
+| BlockDirectiveToken  | "server"と"location"  |
 | SingleDirectiveToken | "listen"とか           |
 | OpenBraceToken       | "{"                  |
 | CloseBraceToken      | "}"                  |
@@ -96,10 +96,10 @@ classDiagram
 
 <!-- TOOD(iyamada) block_directive, single_directive, location_directiveは一つしかパースできない -->
 
-```
-config             ::= block_directive
-block_directive    ::= ("server" | "location" value ) "{" ( single_directive | location_directive ) "}"
-location_directive ::= "location" value "{" ( single_directive )+ "}"
+```bnf
+config             ::= ( block_directive | single_directive )*
+block_directive    ::= ("server" | "location" value ) "{" ( single_directive | location_directive )* "}"
+location_directive ::= "location" value "{" ( single_directive )* "}"
 single_directive   ::= ( "listen" | "alias" | "autoindex" ) value ";"
 value              ::= (英数字 | ".")+
 ```
@@ -107,6 +107,7 @@ value              ::= (英数字 | ".")+
 - メタ構文の意味
   - "\[hoge\]" : hogeは0か1個
   - "hoge+" : hogeは1個以上
+  - "hoge\*" : hogeは0個以上
 
 ## 擬似コード
 

--- a/srcs/Config/ConfigGenerator.cpp
+++ b/srcs/Config/ConfigGenerator.cpp
@@ -128,23 +128,9 @@ LocationContext ConfigGenerator::GenerateLocationContext(Node node) {
         }
 
         if (itr->IsAutoindexDirective()) {
-            std::list<std::string> direciteve_vals = itr->directive_vals();
-            if (direciteve_vals.size() != 1) {
-                // TODO(takkatao) エラー処理
-                throw std::runtime_error(
-                    "Syntax Error: autoindex directive can only take one "
-                    "value");
-            }
-            std::string directive_val = direciteve_vals.back();
-            if (directive_val == "on") {
-                locate.set_auto_index(true);
-            } else if (directive_val == "off") {
-                locate.set_auto_index(false);
-            } else {
-                // TODO(takkatao) エラー処理
-                throw std::runtime_error(
-                    "Syntax Error: autoindex directive can only take on/off");
-            }
+            itr->ValidateDirectiveValue();
+            std::string directive_val = itr->directive_vals().back();
+            locate.set_auto_index(directive_val == "on");
             continue;
         }
 

--- a/srcs/Config/ConfigGenerator.cpp
+++ b/srcs/Config/ConfigGenerator.cpp
@@ -75,6 +75,12 @@ ServerContext ConfigGenerator::GenerateServerContext(Node node) {
             serv.set_port(direciteve_vals.back());
             continue;
         }
+        if (itr->IsAutoindexDirective()) {
+            itr->ValidateDirectiveValue();
+            std::string directive_val = itr->directive_vals().back();
+            serv.set_auto_index(directive_val == "on");
+            continue;
+        }
         // TODO(iyamada) エラー処理
         throw std::runtime_error("Unknown directive");
     }

--- a/srcs/Config/ConfigGenerator.cpp
+++ b/srcs/Config/ConfigGenerator.cpp
@@ -37,9 +37,7 @@ WebservConfig ConfigGenerator::GenerateWebservConfig(Node node) {
     for (std::list<Node>::iterator itr = directives.begin();
          itr != directives.end(); ++itr) {
         if (itr->IsAutoindexDirective()) {
-            itr->ValidateDirectiveValue();
-            std::string directive_val = itr->directive_vals().back();
-            conf.set_auto_index(directive_val == "on");
+            conf.set_auto_index(itr->GetAutoindexValueWithValidate() == "on");
             continue;
         }
         // TODO(iyamada) エラー処理
@@ -83,9 +81,7 @@ ServerContext ConfigGenerator::GenerateServerContext(Node node) {
             continue;
         }
         if (itr->IsAutoindexDirective()) {
-            itr->ValidateDirectiveValue();
-            std::string directive_val = itr->directive_vals().back();
-            serv.set_auto_index(directive_val == "on");
+            serv.set_auto_index(itr->GetAutoindexValueWithValidate() == "on");
             continue;
         }
         // TODO(iyamada) エラー処理
@@ -142,9 +138,7 @@ LocationContext ConfigGenerator::GenerateLocationContext(Node node) {
         }
 
         if (itr->IsAutoindexDirective()) {
-            itr->ValidateDirectiveValue();
-            std::string directive_val = itr->directive_vals().back();
-            locate.set_auto_index(directive_val == "on");
+            locate.set_auto_index(itr->GetAutoindexValueWithValidate() == "on");
             continue;
         }
 

--- a/srcs/Config/ConfigGenerator.cpp
+++ b/srcs/Config/ConfigGenerator.cpp
@@ -127,6 +127,27 @@ LocationContext ConfigGenerator::GenerateLocationContext(Node node) {
             continue;
         }
 
+        if (itr->IsAutoindexDirective()) {
+            std::list<std::string> direciteve_vals = itr->directive_vals();
+            if (direciteve_vals.size() != 1) {
+                // TODO(takkatao) エラー処理
+                throw std::runtime_error(
+                    "Syntax Error: autoindex directive can only take one "
+                    "value");
+            }
+            std::string directive_val = direciteve_vals.back();
+            if (directive_val == "on") {
+                locate.set_auto_index(true);
+            } else if (directive_val == "off") {
+                locate.set_auto_index(false);
+            } else {
+                // TODO(takkatao) エラー処理
+                throw std::runtime_error(
+                    "Syntax Error: autoindex directive can only take on/off");
+            }
+            continue;
+        }
+
         // TODO(iyamada) エラー処理
         throw std::runtime_error("Unknown directive");
     }

--- a/srcs/Config/ConfigGenerator.cpp
+++ b/srcs/Config/ConfigGenerator.cpp
@@ -36,8 +36,14 @@ WebservConfig ConfigGenerator::GenerateWebservConfig(Node node) {
     std::list<Node> directives = node.directives();
     for (std::list<Node>::iterator itr = directives.begin();
          itr != directives.end(); ++itr) {
+        if (itr->IsAutoindexDirective()) {
+            itr->ValidateDirectiveValue();
+            std::string directive_val = itr->directive_vals().back();
+            conf.set_auto_index(directive_val == "on");
+            continue;
+        }
         // TODO(iyamada) エラー処理
-        throw std::runtime_error("Unknown directive");
+        throw std::runtime_error("[GenerateWebservConfig]Unknown directive");
     }
 
     std::list<Node> child_context = node.child_contexts();
@@ -48,7 +54,8 @@ WebservConfig ConfigGenerator::GenerateWebservConfig(Node node) {
             continue;
         }
         // TODO(iyamada) エラー処理
-        throw std::runtime_error("Unknown directive");
+        throw std::runtime_error(
+            "[GenerateWebservConfig]Unknown child_context");
     }
 
     return conf;
@@ -82,7 +89,7 @@ ServerContext ConfigGenerator::GenerateServerContext(Node node) {
             continue;
         }
         // TODO(iyamada) エラー処理
-        throw std::runtime_error("Unknown directive");
+        throw std::runtime_error("[GenerateServerContext]Unknown directive");
     }
 
     std::list<Node> child_context = node.child_contexts();
@@ -93,7 +100,8 @@ ServerContext ConfigGenerator::GenerateServerContext(Node node) {
             continue;
         }
         // TODO(iyamada) エラー処理
-        throw std::runtime_error("Unknown directive");
+        throw std::runtime_error(
+            "[GenerateServerContext]Unknown child_context");
     }
 
     return serv;
@@ -141,13 +149,14 @@ LocationContext ConfigGenerator::GenerateLocationContext(Node node) {
         }
 
         // TODO(iyamada) エラー処理
-        throw std::runtime_error("Unknown directive");
+        throw std::runtime_error("[GenerateLocationContext]Unknown directive");
     }
 
     std::list<Node> child_context = node.child_contexts();
     if (!child_context.empty()) {
         // TODO(iyamada) エラー処理
-        throw std::runtime_error("Unknown contexts");
+        throw std::runtime_error(
+            "[GenerateLocationContext]Unknown child_context");
     }
 
     return locate;

--- a/srcs/Config/ConfigLexer.cpp
+++ b/srcs/Config/ConfigLexer.cpp
@@ -84,6 +84,7 @@ ConfigLexer::ConfigLexer(const std::string& content) : content_(content) {
     this->keywords_["location"] = Token::BlockDirective;
     this->keywords_["listen"] = Token::SingleDirective;
     this->keywords_["alias"] = Token::SingleDirective;
+    this->keywords_["autoindex"] = Token::SingleDirective;
     this->keywords_["{"] = Token::OpenBraceToken;
     this->keywords_["}"] = Token::CloseBraceToken;
     this->keywords_[";"] = Token::SemicolonToken;

--- a/srcs/Config/ConfigParser.cpp
+++ b/srcs/Config/ConfigParser.cpp
@@ -5,13 +5,6 @@
 #include <stdexcept>
 #include <string>
 
-/*
-    config           ::= block_directive
-    block_directive  ::= "server" [value] "{" single_directive "}"
-    single_directive ::= "listen" value ";"
-    value            ::= (英数字 | ".")+
-*/
-
 ConfigParser::ConfigParser() {}
 
 ConfigParser::ConfigParser(Token* token) : token_(token) {}

--- a/srcs/Config/ConfigParser.cpp
+++ b/srcs/Config/ConfigParser.cpp
@@ -54,7 +54,6 @@ Node ConfigParser::block_directive() {
         }
     }
 
-    // TODO(iyamada) locationが来たときはlocation_directiveを呼ぶ
     Token::Consume(&this->token_, "}");
 
     return node;

--- a/srcs/Config/ConfigParser.cpp
+++ b/srcs/Config/ConfigParser.cpp
@@ -25,7 +25,15 @@ Node ConfigParser::Parse() { return config(); }
 Node ConfigParser::config() {
     Node head(Node::HttpContextNode);
 
-    head.PushChildContext(block_directive());
+    while (true) {
+        if (Token::SameTokenKind(&this->token_, Token::SingleDirective)) {
+            head.PushDirective(single_directive());
+        } else if (Token::SameTokenKind(&this->token_, Token::BlockDirective)) {
+            head.PushChildContext(block_directive());
+        } else {
+            break;
+        }
+    }
 
     return head;
 }

--- a/srcs/Config/ConfigParser.cpp
+++ b/srcs/Config/ConfigParser.cpp
@@ -53,7 +53,11 @@ Node ConfigParser::block_directive() {
         Token::Consume(&this->token_, "{");
     }
 
-    while (!Token::SameToken(&this->token_, "}")) {
+    while (true) {
+        if (Token::SameToken(&this->token_, "}")) {
+            Token::Consume(&this->token_, "}");
+            break;
+        }
         if (Token::SameTokenKind(&this->token_, Token::SingleDirective)) {
             node.PushDirective(single_directive());
         }
@@ -61,8 +65,6 @@ Node ConfigParser::block_directive() {
             node.PushChildContext(location_directive());
         }
     }
-
-    Token::Consume(&this->token_, "}");
 
     return node;
 }

--- a/srcs/Config/ConfigParser.cpp
+++ b/srcs/Config/ConfigParser.cpp
@@ -72,7 +72,11 @@ Node ConfigParser::location_directive() {
     node.set_kind(Node::LocationContextNode);
     value(&node);
     Token::Consume(&this->token_, "{");
-    node.PushDirective(single_directive());
+
+    while (!Token::SameToken(&this->token_, "}")) {
+        node.PushDirective(single_directive());
+    }
+
     Token::Consume(&this->token_, "}");
 
     return node;
@@ -89,6 +93,8 @@ Node ConfigParser::single_directive() {
         node = Node::NewNode(Node::ListenDirectiveNode);
     } else if (Token::Expect(&this->token_, "alias")) {
         node = Node::NewNode(Node::AliasDirectiveNode);
+    } else if (Token::Expect(&this->token_, "autoindex")) {
+        node = Node::NewNode(Node::AutoindexDirectiveNode);
     }
 
     value(&node);

--- a/srcs/Config/ConfigParser.cpp
+++ b/srcs/Config/ConfigParser.cpp
@@ -54,8 +54,7 @@ Node ConfigParser::block_directive() {
     }
 
     while (true) {
-        if (Token::SameToken(&this->token_, "}")) {
-            Token::Consume(&this->token_, "}");
+        if (Token::Expect(&this->token_, "}")) {
             break;
         }
         if (Token::SameTokenKind(&this->token_, Token::SingleDirective)) {

--- a/srcs/Config/ConfigParser.cpp
+++ b/srcs/Config/ConfigParser.cpp
@@ -45,11 +45,13 @@ Node ConfigParser::block_directive() {
         Token::Consume(&this->token_, "{");
     }
 
-    if (Token::SameTokenKind(&this->token_, Token::SingleDirective)) {
-        node.PushDirective(single_directive());
-    }
-    if (Token::SameToken(&this->token_, "location")) {
-        node.PushChildContext(location_directive());
+    while (!Token::SameToken(&this->token_, "}")) {
+        if (Token::SameTokenKind(&this->token_, Token::SingleDirective)) {
+            node.PushDirective(single_directive());
+        }
+        if (Token::SameToken(&this->token_, "location")) {
+            node.PushChildContext(location_directive());
+        }
     }
 
     // TODO(iyamada) locationが来たときはlocation_directiveを呼ぶ

--- a/srcs/Config/Node.cpp
+++ b/srcs/Config/Node.cpp
@@ -64,7 +64,7 @@ bool Node::IsAutoindexDirective() {
 void Node::PushDirective(Node node) { directives_.push_back(node); }
 void Node::PushChildContext(Node node) { child_contexts_.push_back(node); }
 
-void Node::ValidateDirectiveValue() {
+void Node::ValidateAutoindexValue() {
     if (this->IsAutoindexDirective()) {
         std::list<std::string> direciteve_vals = this->directive_vals();
         if (direciteve_vals.size() != 1) {
@@ -80,6 +80,12 @@ void Node::ValidateDirectiveValue() {
                 "Syntax Error: autoindex directive can only take on/off");
         }
     }
+}
+
+std::string Node::GetAutoindexValueWithValidate() {
+    this->ValidateAutoindexValue();
+    std::string directive_val = this->directive_vals().back();
+    return directive_val;
 }
 
 static void WriteDirevtiveVals(std::ostream& out, std::list<std::string> vals) {

--- a/srcs/Config/Node.cpp
+++ b/srcs/Config/Node.cpp
@@ -64,6 +64,24 @@ bool Node::IsAutoindexDirective() {
 void Node::PushDirective(Node node) { directives_.push_back(node); }
 void Node::PushChildContext(Node node) { child_contexts_.push_back(node); }
 
+void Node::ValidateDirectiveValue() {
+    if (this->IsAutoindexDirective()) {
+        std::list<std::string> direciteve_vals = this->directive_vals();
+        if (direciteve_vals.size() != 1) {
+            // TODO(takkatao) エラー処理
+            throw std::runtime_error(
+                "Syntax Error: autoindex directive can only take one "
+                "value");
+        }
+        std::string directive_val = direciteve_vals.back();
+        if (directive_val != "on" && directive_val != "off") {
+            // TODO(takkatao) エラー処理
+            throw std::runtime_error(
+                "Syntax Error: autoindex directive can only take on/off");
+        }
+    }
+}
+
 static void WriteDirevtiveVals(std::ostream& out, std::list<std::string> vals) {
     for (std::list<std::string>::iterator v_itr = vals.begin();
          v_itr != vals.end(); ++v_itr) {

--- a/srcs/Config/Node.cpp
+++ b/srcs/Config/Node.cpp
@@ -57,6 +57,9 @@ bool Node::IsServerContext() { return kind_ == Node::ServerContextNode; }
 bool Node::IsLocationContext() { return kind_ == Node::LocationContextNode; }
 bool Node::IsListenDirective() { return kind_ == Node::ListenDirectiveNode; }
 bool Node::IsAliasDirective() { return kind_ == Node::AliasDirectiveNode; }
+bool Node::IsAutoindexDirective() {
+    return kind_ == Node::AutoindexDirectiveNode;
+}
 
 void Node::PushDirective(Node node) { directives_.push_back(node); }
 void Node::PushChildContext(Node node) { child_contexts_.push_back(node); }

--- a/srcs/Config/Node.hpp
+++ b/srcs/Config/Node.hpp
@@ -48,6 +48,8 @@ class Node {
     void PushDirective(Node node);
     void PushChildContext(Node node);
 
+    void ValidateDirectiveValue();
+
  private:
     NodeKind kind_;
     // TODO(iyamada)

--- a/srcs/Config/Node.hpp
+++ b/srcs/Config/Node.hpp
@@ -48,7 +48,8 @@ class Node {
     void PushDirective(Node node);
     void PushChildContext(Node node);
 
-    void ValidateDirectiveValue();
+    void ValidateAutoindexValue();
+    std::string GetAutoindexValueWithValidate();
 
  private:
     NodeKind kind_;

--- a/srcs/Config/Node.hpp
+++ b/srcs/Config/Node.hpp
@@ -14,7 +14,8 @@ class Node {
         ServerContextNode,
         LocationContextNode,
         ListenDirectiveNode,
-        AliasDirectiveNode
+        AliasDirectiveNode,
+        AutoindexDirectiveNode
     };
 
     Node();
@@ -40,6 +41,7 @@ class Node {
     bool IsLocationContext();
     bool IsListenDirective();
     bool IsAliasDirective();
+    bool IsAutoindexDirective();
 
     // TODO(iyamada)
     // どっかでPopするかのと思い、PushにしたけどAddとかの方が直感的かもしれない

--- a/srcs/Config/WebservConfig.cpp
+++ b/srcs/Config/WebservConfig.cpp
@@ -57,7 +57,11 @@ void WebservConfig::PushErrorPage(int status_code,
 }
 
 WebservConfig WebservConfig::Parse() {
-    ConfigProcesser conf_proc("test_data/config/webserv/default.conf");
+    return Parse("test_data/config/webserv/default.conf");
+}
+
+WebservConfig WebservConfig::Parse(std::string str) {
+    ConfigProcesser conf_proc(str);
 
     return conf_proc.Exec();
 }

--- a/srcs/Config/WebservConfig.hpp
+++ b/srcs/Config/WebservConfig.hpp
@@ -30,6 +30,7 @@ class WebservConfig {
     void PushErrorPage(int status_code, const std::string& error_page);
 
     static WebservConfig Parse();
+    static WebservConfig Parse(std::string);
     std::vector<ServerLocation>* CreateServerLocations();
 
  private:

--- a/srcs/Webserv/Webserv.cpp
+++ b/srcs/Webserv/Webserv.cpp
@@ -1,5 +1,6 @@
 #include "Webserv.hpp"
 
+#include <string>
 #include <vector>
 
 #include "ServerLocation.hpp"
@@ -21,9 +22,15 @@ Webserv &Webserv::operator=(Webserv const &other) {
 Webserv::~Webserv() {}
 
 void Webserv::Run(int argc, char **argv) {
-    (void)argc;
-    this->logging_.Debug(argv[0]);
-    WebservConfig config = WebservConfig::Parse();
+    WebservConfig config;
+    // TODO(takkatao): 引数の数が多い時のエラー処理を追加。
+    if (argc == 2) {
+        this->logging_.Debug("config : " + std::string(argv[1]));
+        config = WebservConfig::Parse(argv[1]);
+    } else {
+        this->logging_.Debug("config : default");
+        config = WebservConfig::Parse();
+    }
     std::vector<ServerLocation> *locations = config.CreateServerLocations();
     ServerLocationFacade facade(locations);
     SuperVisor sv(facade);

--- a/test_data/config/webserv/ok/autoindex_on_http.conf
+++ b/test_data/config/webserv/ok/autoindex_on_http.conf
@@ -1,0 +1,7 @@
+autoindex on;
+server {
+  listen 80;
+   location / {
+    alias /var/www/html;
+  }
+}

--- a/test_data/config/webserv/ok/autoindex_on_location.conf
+++ b/test_data/config/webserv/ok/autoindex_on_location.conf
@@ -2,6 +2,6 @@ server {
   listen 80;
   location / {
     alias /var/www/html;
-    autoindex off;
+    autoindex on;
   }
 }

--- a/test_data/config/webserv/ok/autoindex_on_server.conf
+++ b/test_data/config/webserv/ok/autoindex_on_server.conf
@@ -1,0 +1,7 @@
+server {
+  listen 80;
+  autoindex on;
+  location / {
+    alias /var/www/html;
+  }
+}

--- a/test_data/config/webserv/ok/multi_directive.conf
+++ b/test_data/config/webserv/ok/multi_directive.conf
@@ -1,0 +1,22 @@
+autoindex on;
+autoindex on;
+server {
+  listen 80;
+  autoindex on;
+  location / {
+    alias /var/www/html;
+    autoindex on;
+  }
+  location / {
+    alias /var/www/html;
+  }
+  location / {
+    alias /var/www/html;
+  }
+}
+server {
+  listen 80;
+   location / {
+    alias /var/www/html;
+  }
+}

--- a/tests/unit_test/ConfigParser.cpp
+++ b/tests/unit_test/ConfigParser.cpp
@@ -85,3 +85,33 @@ TEST_F(ConfigParserTest, autoindex_on_server) {
     LocationContext locate_context = locate_contexts.at(0);
     ASSERT_EQ(locate_context.auto_index(), false);
 }
+
+TEST_F(ConfigParserTest, autoindex_on_http) {
+    ConfigProcesser confproc(
+        "../../../test_data/config/webserv/ok/autoindex_on_http.conf");
+    WebservConfig conf = confproc.Exec();
+
+    ASSERT_EQ(conf.auto_index(), true);
+
+    std::vector<ServerContext> serv_contexts = conf.contexts();
+    ServerContext serv_context = serv_contexts.at(0);
+    ASSERT_EQ(serv_context.auto_index(), false);
+
+    std::vector<LocationContext> locate_contexts = serv_context.contexts();
+    LocationContext locate_context = locate_contexts.at(0);
+    ASSERT_EQ(locate_context.auto_index(), false);
+}
+
+TEST_F(ConfigParserTest, multi_directive) {
+    ConfigProcesser confproc(
+        "../../../test_data/config/webserv/ok/multi_directive.conf");
+    WebservConfig conf = confproc.Exec();
+    std::vector<ServerContext> serv_contexts = conf.contexts();
+
+    ASSERT_EQ(serv_contexts.size(), 2);
+
+    ServerContext serv_context = serv_contexts.at(0);
+
+    std::vector<LocationContext> locate_contexts = serv_context.contexts();
+    ASSERT_EQ(locate_contexts.size(), 3);
+}

--- a/tests/unit_test/ConfigParser.cpp
+++ b/tests/unit_test/ConfigParser.cpp
@@ -53,3 +53,19 @@ TEST_F(ConfigParserTest, LocationContextInServerContext) {
     ASSERT_EQ(locate_context.path(), "/");
     ASSERT_EQ(locate_context.redirect_uri(), "");
 }
+
+TEST_F(ConfigParserTest, autoindex_on_location) {
+    ConfigProcesser confproc(
+        "../../../test_data/config/webserv/ok/autoindex_on_location.conf");
+    WebservConfig conf = confproc.Exec();
+
+    ASSERT_EQ(conf.auto_index(), false);
+
+    std::vector<ServerContext> serv_contexts = conf.contexts();
+    ServerContext serv_context = serv_contexts.at(0);
+    ASSERT_EQ(serv_context.auto_index(), false);
+
+    std::vector<LocationContext> locate_contexts = serv_context.contexts();
+    LocationContext locate_context = locate_contexts.at(0);
+    ASSERT_EQ(locate_context.auto_index(), true);
+}

--- a/tests/unit_test/ConfigParser.cpp
+++ b/tests/unit_test/ConfigParser.cpp
@@ -69,3 +69,19 @@ TEST_F(ConfigParserTest, autoindex_on_location) {
     LocationContext locate_context = locate_contexts.at(0);
     ASSERT_EQ(locate_context.auto_index(), true);
 }
+
+TEST_F(ConfigParserTest, autoindex_on_server) {
+    ConfigProcesser confproc(
+        "../../../test_data/config/webserv/ok/autoindex_on_server.conf");
+    WebservConfig conf = confproc.Exec();
+
+    ASSERT_EQ(conf.auto_index(), false);
+
+    std::vector<ServerContext> serv_contexts = conf.contexts();
+    ServerContext serv_context = serv_contexts.at(0);
+    ASSERT_EQ(serv_context.auto_index(), true);
+
+    std::vector<LocationContext> locate_contexts = serv_context.contexts();
+    LocationContext locate_context = locate_contexts.at(0);
+    ASSERT_EQ(locate_context.auto_index(), false);
+}


### PR DESCRIPTION
# 対応したこと
## 複数ディレクティブ対応
- [x] locationコンテキストで、複数ディレクティブを記載可能にする
- [x] Serverコンテキストで、複数ディレクティブを記載可能にする
- [x] HTTPコンテキストに、Server/Location以外のディレクティブを記載可能にする。
- [x] HTTPコンテキストで、複数ディレクティブを記載可能にする

## autoindexディレクティブ対応
- [x] locationコンテキストで、autoindexディレクティブを記載可能にする
- [x] Serverコンテキストで、autoindexディレクティブを記載可能にする
- [x] HTTPコンテキストで、autoindexディレクティブを記載可能にする

## その他
- [x] 引数でconfigファイルのパスを指定できるようにする。（デバッグのために追加しました。）

# 対応しないこと
- autoindex以外の内容は別チケットにします。（ちょろならまとめて対応と思ってましたが、大きなプルリクになりそうだったので細かく区切ります。）