### PR TITLE
統合テスト高速化

### DIFF
--- a/docker/webserv/tools/start.sh
+++ b/docker/webserv/tools/start.sh
@@ -1,4 +1,3 @@
 cd /app
-make -j
 mkdir -p /app/log
 ./webserv ./test_data/config/webserv/ok/localhost > /app/log/log.txt


### PR DESCRIPTION
before: `make itest  0.74s user 0.64s system 4% cpu 30.072 total`
after  : `make itest  0.73s user 0.50s system 14% cpu 8.293 total`

- コンテナのプロセスキルがちょっと煩雑そうだったので、down&upで対応した。
-  makeを別コマンドにすることで、sleepをチューニングした。