### PR TITLE
Lexerでunknow dirctiveを弾けるように&server_nameディレクティブ対応

### DIFF
--- a/srcs/Config/ConfigGenerator.cpp
+++ b/srcs/Config/ConfigGenerator.cpp
@@ -92,6 +92,12 @@ ServerContext ConfigGenerator::GenerateServerContext(Node node) {
             continue;
         }
 
+        if (itr->IsServerNameDirective()) {
+            itr->ValidateSize(1);
+            serv.set_server_name(itr->GetValue());
+            continue;
+        }
+
         // TODO(iyamada) エラー処理
         throw std::runtime_error("[GenerateServerContext]Unknown directive");
     }

--- a/srcs/Config/ConfigLexer.cpp
+++ b/srcs/Config/ConfigLexer.cpp
@@ -23,6 +23,7 @@ ConfigLexer::ConfigLexer(const std::string& content) : content_(content) {
     this->keywords_["autoindex"] = Token::SingleDirective;
     this->keywords_["return"] = Token::SingleDirective;
     this->keywords_["cgi_extension"] = Token::SingleDirective;
+    this->keywords_["server_name"] = Token::SingleDirective;
 
     this->controls_["{"] = Token::OpenBraceToken;
     this->controls_["}"] = Token::CloseBraceToken;

--- a/srcs/Config/ConfigLexer.cpp
+++ b/srcs/Config/ConfigLexer.cpp
@@ -10,6 +10,7 @@ static std::string ErrorMessageUnknownDirective(const std::string& keyword) {
     ss << "unknown directive \"";
     ss << keyword;
     ss << "\"";
+    return ss.str();
 }
 
 ConfigLexer::ConfigLexer() {}

--- a/srcs/Config/ConfigLexer.cpp
+++ b/srcs/Config/ConfigLexer.cpp
@@ -53,7 +53,7 @@ std::string ConfigLexer::ReadKeyword() {
 Token* ConfigLexer::Tokenize() {
     Token head;
     Token* cur_tok = &head;
-    bool expectValue = false;
+    bool is_expected_value = false;
 
     while (true) {
         this->content_ = SkipSpace(this->content_);
@@ -70,11 +70,11 @@ Token* ConfigLexer::Tokenize() {
             cur_tok =
                 Token::NewToken(cur_tok, this->controls_.at(keyword), keyword);
             this->content_ = ConsumeWithSpace(this->content_, keyword);
-            expectValue = false;
+            is_expected_value = false;
             continue;
         }
 
-        if (expectValue) {
+        if (is_expected_value) {
             // valueの処理
             cur_tok = Token::NewToken(cur_tok, Token::ValueToken,
                                       GetValueCharacters(this->content_));
@@ -85,7 +85,7 @@ Token* ConfigLexer::Tokenize() {
                 Token::TokenKind kind = this->keywords_.at(keyword);
                 cur_tok = Token::NewToken(cur_tok, kind, keyword);
                 this->content_ = ConsumeWithSpace(this->content_, keyword);
-                expectValue = true;
+                is_expected_value = true;
             } catch (std::exception& e) {
                 throw std::runtime_error(ErrorMessageUnknownDirective(keyword));
             }

--- a/srcs/Config/ConfigLexer.hpp
+++ b/srcs/Config/ConfigLexer.hpp
@@ -21,9 +21,8 @@ class ConfigLexer {
  private:
     std::string content_;
     std::map<std::string, Token::TokenKind> keywords_;
+    std::map<std::string, Token::TokenKind> controls_;
 
-    bool IsBlockDirectiveKeyword(std::string keyword);
-    bool IsSingleDirectiveKeyword(std::string keyword);
     std::string ReadKeyword();
 };
 

--- a/srcs/Config/ConfigParser.cpp
+++ b/srcs/Config/ConfigParser.cpp
@@ -99,6 +99,7 @@ Node ConfigParser::single_directive() {
     token_node_map["autoindex"] = Node::AutoindexDirectiveNode;
     token_node_map["return"] = Node::ReturnDirectiveNode;
     token_node_map["cgi_extension"] = Node::CgiExtDirectiveNode;
+    token_node_map["server_name"] = Node::ServerNameDirectiveNode;
 
     std::map<std::string, Node::NodeKind>::iterator itr;
     for (itr = token_node_map.begin(); itr != token_node_map.end(); ++itr) {

--- a/srcs/Config/Node.cpp
+++ b/srcs/Config/Node.cpp
@@ -62,6 +62,9 @@ bool Node::IsAliasDirective() { return kind_ == Node::AliasDirectiveNode; }
 bool Node::IsAutoindexDirective() {
     return kind_ == Node::AutoindexDirectiveNode;
 }
+bool Node::IsServerNameDirective() {
+    return kind_ == Node::ServerNameDirectiveNode;
+}
 
 bool Node::IsReturnDirective() { return kind_ == Node::ReturnDirectiveNode; }
 

--- a/srcs/Config/Node.hpp
+++ b/srcs/Config/Node.hpp
@@ -18,7 +18,7 @@ class Node {
         AutoindexDirectiveNode,
         ReturnDirectiveNode,
         CgiExtDirectiveNode,
-        ServerNameDirectiveNode,
+        ServerNameDirectiveNode
     };
 
     Node();

--- a/srcs/Config/Node.hpp
+++ b/srcs/Config/Node.hpp
@@ -17,7 +17,8 @@ class Node {
         AliasDirectiveNode,
         AutoindexDirectiveNode,
         ReturnDirectiveNode,
-        CgiExtDirectiveNode
+        CgiExtDirectiveNode,
+        ServerNameDirectiveNode,
     };
 
     Node();
@@ -46,6 +47,7 @@ class Node {
     bool IsAutoindexDirective();
     bool IsReturnDirective();
     bool IsCgiExtensionDirective();
+    bool IsServerNameDirective();
 
     // TODO(iyamada)
     // どっかでPopするかのと思い、PushにしたけどAddとかの方が直感的かもしれない

--- a/test_data/config/webserv/default.conf
+++ b/test_data/config/webserv/default.conf
@@ -1,5 +1,6 @@
 server {
   listen 80;
+  server_name default;
   location / {
     alias /app/sample_data/html;
     autoindex off;

--- a/tests/unit_test/ConfigParser.cpp
+++ b/tests/unit_test/ConfigParser.cpp
@@ -28,6 +28,7 @@ TEST_F(ConfigParserTest, LocationContextInServerContext) {
 
     ASSERT_EQ(serv_context.contexts().size(), 2);
     ASSERT_EQ(serv_context.port(), 80);
+    ASSERT_EQ(serv_context.server_name(), "default");
 
     std::vector<LocationContext> locate_contexts = serv_context.contexts();
     ASSERT_EQ(locate_contexts.size(), 2);

--- a/tests/unit_test/ServerLocationFacade.cpp
+++ b/tests/unit_test/ServerLocationFacade.cpp
@@ -19,7 +19,7 @@ TEST_F(ServerLocationFacadeTest, basic) {
     ServerLocationFacade facade(locations);
     ServerLocation sl = facade.Choose("80", "", "/");
     ASSERT_EQ(80, sl.port());
-    ASSERT_EQ("", sl.host());
+    ASSERT_EQ("default", sl.host());
     ASSERT_EQ("/", sl.path());
     ASSERT_EQ("/app/sample_data/html", sl.alias());
     ASSERT_EQ("off", sl.auto_index());
@@ -32,7 +32,7 @@ TEST_F(ServerLocationFacadeTest, default_server) {
     ServerLocationFacade facade(locations);
     ServerLocation sl = facade.Choose("80", "not_matching", "/");
     ASSERT_EQ(80, sl.port());
-    ASSERT_EQ("", sl.host());
+    ASSERT_EQ("default", sl.host());
     ASSERT_EQ("/", sl.path());
     ASSERT_EQ("/app/sample_data/html", sl.alias());
     ASSERT_EQ("off", sl.auto_index());
@@ -45,7 +45,7 @@ TEST_F(ServerLocationFacadeTest, longest_path_match) {
     ServerLocationFacade facade(locations);
     ServerLocation sl = facade.Choose("80", "", "/files/hoge.html");
     ASSERT_EQ(80, sl.port());
-    ASSERT_EQ("", sl.host());
+    ASSERT_EQ("default", sl.host());
     ASSERT_EQ("/files/", sl.path());
     ASSERT_EQ("/app/sample_data/files", sl.alias());
     ASSERT_EQ("off", sl.auto_index());


### PR DESCRIPTION
以下を対応しました。
- unknow directiveを弾けるように
- server_nameディレクティブをparseできるように

lexerの処理で文脈を考慮することでdirectiveが期待される箇所とvalueが期待される箇所を区別して読み込めるようにした。