### PR TITLE
stress test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,27 @@ dc-nginx-re: dc-nginx-down dc-nginx-build dc-nginx-up ## Rebuild nginx image and
 dc-prune: ## Delete unused docker object (images, containers, networks)
 	docker system  prune
 
+# ----------------------- Rules For Nginx Container -----------------------
+
+.PHONY: dc-siege-build
+dc-siege-build: ## Build siege container
+	make dc-build CONTAINER=siege
+
+.PHONY: dc-siege-up
+dc-siege-up: ## Run siege container
+	make dc-up CONTAINER=siege
+
+.PHONY: dc-siege-login
+dc-siege-login: ## Login siege container
+	make dc-login CONTAINER=siege
+
+.PHONY: dc-siege-down
+dc-siege-down: ## Down siege container
+	make dc-down CONTAINER=siege
+
+.PHONY: dc-siege-re 
+dc-siege-re: dc-siege-down dc-siege-build dc-siege-up ## Rebuild siege image and run container
+
 # ---------------------------- Rules For Help -----------------------------
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,17 @@ dc-siege-down: ## Down siege container
 .PHONY: dc-siege-re 
 dc-siege-re: dc-siege-down dc-siege-build dc-siege-up ## Rebuild siege image and run container
 
+
+.PHONY: stress
+stress: ## Do Stress Test on siege container
+	@echo "start stress test"
+	@echo "rebuild docker container"
+	@make dc-siege-re
+	@echo "start stress test for 30 sec."
+	@docker compose -f ./docker/siege/docker-compose.yml exec -T siege bash start.sh
+	@echo ""
+	@echo "Finish Stress test. You can see ./log/siege.log and ./log/top.log"
+
 # ---------------------------- Rules For Help -----------------------------
 
 .PHONY: help

--- a/docker/siege/Dockerfile
+++ b/docker/siege/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:stable-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+	make \
+	g++ \
+	procps \
+	siege
+
+COPY ./tools/start.sh /usr/local/bin
+# prevent container from terminating
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/docker/siege/docker-compose.yml
+++ b/docker/siege/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.7'
+
+services:
+  siege:
+    container_name: siege
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/app

--- a/docker/siege/tools/start.sh
+++ b/docker/siege/tools/start.sh
@@ -1,0 +1,6 @@
+cd /app
+mkdir -p /app/log
+./webserv ./test_data/config/webserv/ok/default.conf > /app/log/log.txt &
+sleep 1
+
+./tests/stress_test/stress_test.sh > /app/log/siege.log 

--- a/docker/siege/tools/start.sh
+++ b/docker/siege/tools/start.sh
@@ -1,6 +1,18 @@
 cd /app
+make
 mkdir -p /app/log
 ./webserv ./test_data/config/webserv/ok/default.conf > /app/log/log.txt &
 sleep 1
 
-./tests/stress_test/stress_test.sh > /app/log/siege.log 
+#[options]
+#-b: --benchmark ベンチマークモード。ディレイを無効にする。
+siege -b http://localhost/ > /app/log/siege.log &
+
+# topを1秒ごとに20回繰り返す
+#-b: バッチモード（対話的な入力を受け付けないで、結果を全て出力）
+#-d: 実行間隔（秒）
+#-n: 実行回数（回）
+top -b -n 1 |grep MEM > /app/log/top.log #ラベル行出力用
+top -b -d 1 -n 20 |grep webserv >> /app/log/top.log
+pkill siege
+sleep 1

--- a/srcs/Http/HTTPResponse.hpp
+++ b/srcs/Http/HTTPResponse.hpp
@@ -1,8 +1,6 @@
 #ifndef SRCS_HTTP_HTTPRESPONSE_HPP_
 #define SRCS_HTTP_HTTPRESPONSE_HPP_
 
-#include <gtest/gtest_prod.h>
-
 #include <string>
 
 #include "Logging.hpp"

--- a/tests/stress_test/stress_test.sh
+++ b/tests/stress_test/stress_test.sh
@@ -1,0 +1,4 @@
+#[options]
+#-b: --benchmark ベンチマークモード。ディレイを無効にする。
+
+siege -b http://localhost/

--- a/tests/stress_test/stress_test.sh
+++ b/tests/stress_test/stress_test.sh
@@ -1,4 +1,0 @@
-#[options]
-#-b: --benchmark ベンチマークモード。ディレイを無効にする。
-
-siege -b http://localhost/


### PR DESCRIPTION
## 使い方

`make stress`で実行。
- siegeが入ったコンテナが起動される。（webserbとは別コンテナ。siegeインストールで、CIを遅くしたくなかったので。）
- siegeの実行ログが./log/siege.logに出力される。レビュー要件：`availability should be avobe 99.5%`
- siege実行中のtopコマン後のログが、./log/top.logに出力される。レビュー要件：`Verify there is no memory leaks.(Monitor the process memory usage. It should not go up infinitely.)`