### PR TITLE
stress test on github

### DIFF
--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -9,3 +9,12 @@ jobs:
       - name: stress
         shell: bash
         run: make stress
+      - name: log
+        shell: bash
+        run: cat ./log/log.txt
+      - name: siege_log
+        shell: bash
+        run: cat ./log/siege.log
+      - name: top_log
+        shell: bash
+        run: cat ./log/top.log

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -1,4 +1,4 @@
-name: checker
+name: stress_test
 on: workflow_dispatch
 
 jobs:

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -1,0 +1,11 @@
+name: checker
+on: workflow_dispatch
+
+jobs:
+  stress-tets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: stress
+        shell: bash
+        run: make stress

--- a/docker/siege/tools/start.sh
+++ b/docker/siege/tools/start.sh
@@ -13,6 +13,6 @@ siege -b http://localhost/ > /app/log/siege.log &
 #-d: 実行間隔（秒）
 #-n: 実行回数（回）
 top -b -n 1 |grep MEM > /app/log/top.log #ラベル行出力用
-top -b -d 1 -n 20 |grep webserv >> /app/log/top.log
+top -b -d 1 -n 500 |grep webserv >> /app/log/top.log
 pkill siege
 sleep 1


### PR DESCRIPTION
ストレステストをgithub actionsで実行できるようにしました。
`on: workflow_dispatch`で設定しているので、pushごとのCheckは走らず、画面から`Run workflow`ボタンを押すとcheckが走ります。（mainにマージされた後から有効になる。はず。。。）

https://qiita.com/chihiro/items/8b2918ceb709cb9079e8