### PR TITLE
valgrindテストを追加

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -25,7 +25,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
 
   GET_directory:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
 
   GET_incorrect_path:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
 
   GET_incorrect_py_path:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
 
   GET_simple:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
 
   POST_hello_world:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
 
   POST_hello_world_chunked:
     runs-on: ubuntu-latest
@@ -127,4 +127,4 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -25,7 +25,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
+        run: bash ./tests/valgrind/log_check.sh
 
   GET_directory:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
+        run: bash ./tests/valgrind/log_check.sh
 
   GET_incorrect_path:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
+        run: bash ./tests/valgrind/log_check.sh
 
   GET_incorrect_py_path:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
+        run: bash ./tests/valgrind/log_check.sh
 
   GET_simple:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
+        run: bash ./tests/valgrind/log_check.sh
 
   POST_hello_world:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
+        run: bash ./tests/valgrind/log_check.sh
 
   POST_hello_world_chunked:
     runs-on: ubuntu-latest
@@ -127,4 +127,4 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
+        run: bash ./tests/valgrind/log_check.sh

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,21 @@
+name: valgrind
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compose-build
+        shell: bash
+        run: make dc-build
+      - name: valgrind
+        shell: bash
+        run: make valgrind
+      - name: summary log
+        shell: bash
+        run: cat ./log/summary-valgrind.log

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -25,7 +25,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
 
   GET_directory:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
 
   GET_incorrect_path:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
 
   GET_incorrect_py_path:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
 
   GET_simple:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
 
   POST_hello_world:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
 
   POST_hello_world_chunked:
     runs-on: ubuntu-latest
@@ -127,4 +127,4 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -25,7 +25,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
 
   GET_directory:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
 
   GET_incorrect_path:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
 
   GET_incorrect_py_path:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
 
   GET_simple:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
 
   POST_hello_world:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"
 
   POST_hello_world_chunked:
     runs-on: ubuntu-latest
@@ -127,4 +127,4 @@ jobs:
         run: cat ./log/summary-valgrind.log
       - name: log check
         shell: bash
-        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc -l | grep " 0       0       0"
+        run: grep definitely ./log/summary-valgrind.log  | grep -v "0 byte" | wc | grep " 0       0       0"

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -3,10 +3,14 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "sample_data"
+      - "README.md"
 
 jobs:
-  valgrind:
+  GET_cgi_error_exit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,7 +19,109 @@ jobs:
         run: make dc-build
       - name: valgrind
         shell: bash
-        run: make valgrind
+        run: bash ./tests/valgrind/valgrind.sh GET_cgi_error_exit.txt
+      - name: summary log
+        shell: bash
+        run: cat ./log/summary-valgrind.log
+      - name: log check
+        shell: bash
+        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+
+  GET_directory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compose-build
+        shell: bash
+        run: make dc-build
+      - name: valgrind
+        shell: bash
+        run: bash ./tests/valgrind/valgrind.sh GET_directory.txt
+      - name: summary log
+        shell: bash
+        run: cat ./log/summary-valgrind.log
+      - name: log check
+        shell: bash
+        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+
+  GET_incorrect_path:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compose-build
+        shell: bash
+        run: make dc-build
+      - name: valgrind
+        shell: bash
+        run: bash ./tests/valgrind/valgrind.sh GET_incorrect_path.txt
+      - name: summary log
+        shell: bash
+        run: cat ./log/summary-valgrind.log
+      - name: log check
+        shell: bash
+        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+
+  GET_incorrect_py_path:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compose-build
+        shell: bash
+        run: make dc-build
+      - name: valgrind
+        shell: bash
+        run: bash ./tests/valgrind/valgrind.sh GET_incorrect_py_path.txt
+      - name: summary log
+        shell: bash
+        run: cat ./log/summary-valgrind.log
+      - name: log check
+        shell: bash
+        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+
+  GET_simple:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compose-build
+        shell: bash
+        run: make dc-build
+      - name: valgrind
+        shell: bash
+        run: bash ./tests/valgrind/valgrind.sh GET_simple.txt
+      - name: summary log
+        shell: bash
+        run: cat ./log/summary-valgrind.log
+      - name: log check
+        shell: bash
+        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+
+  POST_hello_world:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compose-build
+        shell: bash
+        run: make dc-build
+      - name: valgrind
+        shell: bash
+        run: bash ./tests/valgrind/valgrind.sh POST_hello_world.txt
+      - name: summary log
+        shell: bash
+        run: cat ./log/summary-valgrind.log
+      - name: log check
+        shell: bash
+        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
+
+  POST_hello_world_chunked:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compose-build
+        shell: bash
+        run: make dc-build
+      - name: valgrind
+        shell: bash
+        run: bash ./tests/valgrind/valgrind.sh POST_hello_world_chunked.txt
       - name: summary log
         shell: bash
         run: cat ./log/summary-valgrind.log

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -19,3 +19,6 @@ jobs:
       - name: summary log
         shell: bash
         run: cat ./log/summary-valgrind.log
+      - name: log check
+        shell: bash
+        run: ! grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,14 @@ itest-error: ## Exec unit tests for webserver
 	fi
 	$(INTEGRATION_TEST_SHELL_ERROR)
 
+VALGRIND_TEST_SHELL = ./tests/valgrind/valgrind.sh
+.PHONY: valgrind
+valgrind: ## Exec valgrind tests for webserver
+	@if [ ! -x $(VALGRIND_TEST_SHELL) ]; then\
+		chmod +x $(VALGRIND_TEST_SHELL);\
+	fi
+	$(VALGRIND_TEST_SHELL)
+
 # -------------------- Rules For Static Analyser --------------------------
 
 .PHONY: format

--- a/tests/valgrind/log_check.sh
+++ b/tests/valgrind/log_check.sh
@@ -2,7 +2,8 @@
 
 CONFIG_FILE=./log/summary-valgrind.log
 
+grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"
 # ログファイルにリークが含まれていた場合はexit 1.
-if [ `grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"` ] ; then
+if [ $? -eq 0 ] ; then
     exit 1
 fi

--- a/tests/valgrind/log_check.sh
+++ b/tests/valgrind/log_check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+CONFIG_FILE=./log/summary-valgrind.log
+
+# ログファイルにリークが含まれていた場合はexit 1.
+if [ `grep definitely ./log/summary-valgrind.log  | grep -v "0 byte"` ] ; then
+    exit 1
+fi

--- a/tests/valgrind/valgrind.sh
+++ b/tests/valgrind/valgrind.sh
@@ -24,7 +24,7 @@ function do_valgrind_test() {
     echo ""  >> ./log/summary-valgrind.log
 }
 
-
+mkdir -p ./log
 make dc-re > /dev/null 2>&1
 docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv make > /dev/null 2>&1
 

--- a/tests/valgrind/valgrind.sh
+++ b/tests/valgrind/valgrind.sh
@@ -6,6 +6,25 @@ REQUEST_ARRAY=(`ls ${REQUEST_PATH}`)
 CONFIG_PATH=./test_data/config/webserv/ok/
 CONFIG_ARRAY=(`ls ${CONFIG_PATH}`)
 
+function do_valgrind_test() {
+    # valgrind起動
+    docker compose -f ./docker/webserv/docker-compose.yml exec -T -d webserv valgrind --log-file="log/valgrind.log" --leak-check=full ./webserv ${CONFIG_FILE_NAME}
+    sleep 1
+
+    # リクエスト実行
+    nc localhost 8080 < ${REQUEST_FILE_NAME} > /dev/null
+
+    # killでwebservを終了させ、valgrindの結果ファイルを作成する。
+    docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv pkill -SIGINT -f webserv
+    sleep 1
+
+    echo "["${CONFIG_FILE_NAME}"]["${REQUEST_FILE_NAME}"]"
+    echo "["${CONFIG_FILE_NAME}"]["${REQUEST_FILE_NAME}"]" >> ./log/summary-valgrind.log
+    grep definitely < ./log/valgrind.log >> ./log/summary-valgrind.log
+    echo ""  >> ./log/summary-valgrind.log
+}
+
+
 make dc-re > /dev/null 2>&1
 docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv make > /dev/null 2>&1
 
@@ -15,29 +34,24 @@ echo "start valgrind test"
 for CONFIG_NO in "${CONFIG_ARRAY[@]}"
 do 
     CONFIG_FILE_NAME=${CONFIG_PATH}${CONFIG_NO}
+    
+    # 引数がない場合は、全てのrequestファイルを確認する。
+    if [ $# -eq 0 ]; then
+        # requestファイルごとにforループ
+        for REQUEST_NO in "${REQUEST_ARRAY[@]}"
+        do
+            REQUEST_FILE_NAME=${REQUEST_PATH}${REQUEST_NO}
+            do_valgrind_test
+        done
+    fi
 
-    # requestファイルごとにforループ
-    for REQUEST_NO in "${REQUEST_ARRAY[@]}"
-    do 
+    # 引数がある場合は、指定されたrequestファイルのみ確認する。
+    if [ $# -eq 1 ]; then
+        REQUEST_NO=$1
         REQUEST_FILE_NAME=${REQUEST_PATH}${REQUEST_NO}
+        do_valgrind_test
+    fi
 
-        # valgrind起動
-        docker compose -f ./docker/webserv/docker-compose.yml exec -T -d webserv valgrind --log-file="log/valgrind.log" --leak-check=full ./webserv ${CONFIG_FILE_NAME}
-        sleep 1
-
-        # リクエスト実行
-        nc localhost 8080 < ${REQUEST_FILE_NAME} > /dev/null
-        sleep 1
-
-        # killでwebservを終了させ、valgrindの結果ファイルを作成する。
-        docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv pkill -SIGINT -f webserv
-        sleep 1
-
-        echo "["${CONFIG_FILE_NAME}"]["${REQUEST_FILE_NAME}"]" 
-        echo "["${CONFIG_FILE_NAME}"]["${REQUEST_FILE_NAME}"]" >> ./log/summary-valgrind.log
-        grep definitely < ./log/valgrind.log >> ./log/summary-valgrind.log
-        echo ""  >> ./log/summary-valgrind.log
-    done
 done
 
 

--- a/tests/valgrind/valgrind.sh
+++ b/tests/valgrind/valgrind.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+REQUEST_PATH=./test_data/request/ok/
+REQUEST_ARRAY=(`ls ${REQUEST_PATH}`)
+
+CONFIG_PATH=./test_data/config/webserv/ok/
+CONFIG_ARRAY=(`ls ${CONFIG_PATH}`)
+
+make dc-re > /dev/null 2>&1
+docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv make > /dev/null 2>&1
+
+echo "start valgrind test"
+
+# configファイルごとにforループ
+for CONFIG_NO in "${CONFIG_ARRAY[@]}"
+do 
+    CONFIG_FILE_NAME=${CONFIG_PATH}${CONFIG_NO}
+
+    # requestファイルごとにforループ
+    for REQUEST_NO in "${REQUEST_ARRAY[@]}"
+    do 
+        REQUEST_FILE_NAME=${REQUEST_PATH}${REQUEST_NO}
+
+        # valgrind起動
+        docker compose -f ./docker/webserv/docker-compose.yml exec -T -d webserv valgrind --log-file="log/valgrind.log" --leak-check=full ./webserv ${CONFIG_FILE_NAME}
+        sleep 1
+
+        # リクエスト実行
+        nc localhost 8080 < ${REQUEST_FILE_NAME} > /dev/null
+        sleep 1
+
+        # killでwebservを終了させ、valgrindの結果ファイルを作成する。
+        docker compose -f ./docker/webserv/docker-compose.yml exec -T webserv pkill -SIGINT -f webserv
+        sleep 1
+
+        echo "["${CONFIG_FILE_NAME}"]["${REQUEST_FILE_NAME}"]" 
+        echo "["${CONFIG_FILE_NAME}"]["${REQUEST_FILE_NAME}"]" >> ./log/summary-valgrind.log
+        grep definitely < ./log/valgrind.log >> ./log/summary-valgrind.log
+        echo ""  >> ./log/summary-valgrind.log
+    done
+done
+
+
+


### PR DESCRIPTION
`make valgrind`でvalgrindのテストを実行できるように追加。

- 統合テストように用意したconfigファイルとrequestファイルを全ての組み合わせて実行させる。
- valgrindのdefenitly lostが存在しないか確認する。レスポンスの正しらしさは確認しない。
- github actionsで実行可能に。