### PR TITLE
細かい修正

### DIFF
--- a/docs/spec/http.md
+++ b/docs/spec/http.md
@@ -121,7 +121,6 @@ HTTP/1.1 200 OK
 以下のメソッドを設定可能とする。
 
 - GET
-- HEAD
 - POST
 - DELETE
 

--- a/srcs/Socket/Socket.cpp
+++ b/srcs/Socket/Socket.cpp
@@ -82,8 +82,9 @@ int Socket::Accept() const {
     socklen_t addrlen = sizeof(sockaddr);
 
     int new_socket = accept(this->sock_fd_, &clientaddr, &addrlen);
+    // キューがいっぱいの時は例外を投げずそのまま続行
     if (new_socket < 0) {
-        this->logging_.Warn("accept: " + std::string(strerror(errno)));
+        this->logging_.Error("accept: " + std::string(strerror(errno)));
     }
 
     return new_socket;

--- a/srcs/Transaction/CGIExecutor.cpp
+++ b/srcs/Transaction/CGIExecutor.cpp
@@ -183,9 +183,11 @@ CGIResponse CGIExecutor::CGIExec(CGIRequest const &req) {
         Close(pipe_to_serv[1]);
 
         if (req.ShouldSendRequestBody()) {
+            int write_size = Write(pipe_to_cgi[1], req.body());
+
             // writeシステムコールがエラーの場合 -1 が返される。
             // 異常として判定し、例外を投げる。
-            if (Write(pipe_to_cgi[1], req.body()) < 0) {
+            if (write_size < 0) {
                 kill(pid, SIGKILL);  // 子プロセスをkill
                 throw std::runtime_error(strerror(errno));
             }
@@ -193,7 +195,7 @@ CGIResponse CGIExecutor::CGIExec(CGIRequest const &req) {
             // writeされたバイト数が0バイトの場合 0 となる。
             // 今回のwebservの処理では発生しないパターンであるため、
             // 異常として判定し、例外を投げる。
-            if (Write(pipe_to_cgi[1], req.body()) == 0) {
+            if (write_size == 0) {
                 kill(pid, SIGKILL);  // 子プロセスをkill
                 throw std::runtime_error(strerror(errno));
             }


### PR DESCRIPTION
## やったこと

- [x] docsにHEADの記載残ってた。
- [x] SuperVisor.cpp 78行目でlog.Fatalを使うべき。 
     継続可能なエラーなのでErrorにします。
- [x] read/writeのシステムコール戻り値、0の場合の確認ロジック分ける（処理内容自体は同じで、別ロジックとしてコメントをそれぞれ入れる） recv, sendの返り値が0が返ってくる場合.クライアントがコネクションをcloseするとEOFが入ってくる。epoll_waitのイベントで検知しています。 コメントの内容やシステムコールの戻り値の意味なども調べつつ追記する。