### PR TITLE
string overflow

### DIFF
--- a/srcs/Webserv/Worker.cpp
+++ b/srcs/Webserv/Worker.cpp
@@ -40,6 +40,16 @@ bool Worker::ExecReceive(Socket *socket) {
             return true;
         }
         return false;
+    } catch (std::length_error &e) {
+        // リクエストに長い文字列が含まれていて、
+        // stringクラスに上限以上の長さの文字列を入れようとした場合に発生する例外。
+        // 500エラーを返す。
+        logging_.Debug("length_error detected.");
+        ServerLocation sl = this->server_location_facade_->Choose(
+            socket->port(), request->host(), "");
+        HTTPResponse *response = ResponseBuilder::BuildError(500, &sl);
+        request->set_response(response);
+        return true;
     } catch (HTTPException &e) {
         // nginxの挙動に合わせる
         // RequestのParse時のエラーはserverコンテキストの情報だけをみていそう。


### PR DESCRIPTION
client_max_body_sizeについて考慮
複数chunkedの合計が限界を超えているケースは今out 
size_type size() const noexcept;だからsize_typeに合わせるといいかも。 
文字列と比較演算してるところが変更対象？ 
入力として文字列を受け取っている配列の演算処理。

## stringの仕様の調査結果。

stringクラスとして受け付けられる文字列長は内部的に決まっており、[std::string::max_size](https://cplusplus.com/reference/string/string/max_size/)で取得できる。
それを超えるような場合は[std::length_error](https://cplusplus.com/reference/stdexcept/length_error/)が投げられる。

https://cplusplus.com/reference/string/string/string/

## 対応方針
大方針：stringのコンストラクターの例外をキャッチしていく。


### Config
読み込んだ文字列を stringクラスに入れる際に例外の確認を行う。例外が来たらConfig不正として webservプログラム異常終了。
→対応不要。既存実装では「Configファイルの内容全てを1つのstringに入れる」処理を行なっている。この処理でオーバーフローする可能性があるが、例外はキャッチされているので対応不要。

### HTTPRequest::Parser
受信した文字列を stringクラスに入れる際に例外の確認を行う。例外が来たら500エラー返す。（RFC上文字列の長さに規定はないため、リクエスト不正とは言い切れないので、500を返す）
→例外をキャッチする処理を追加。

なお、例外が投げられない場合は、isIntegerでINTの範囲確認を行なっているため、追加の処理は不要。